### PR TITLE
Support for missing token + more placeholders

### DIFF
--- a/src/main/java/me/rojo8399/placeholderapi/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/rojo8399/placeholderapi/PlaceholderAPIPlugin.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 import me.rojo8399.placeholderapi.commands.ParseCommand;
 import me.rojo8399.placeholderapi.configs.Config;
 import me.rojo8399.placeholderapi.expansions.PlayerExpansion;
+import me.rojo8399.placeholderapi.expansions.RankExpansion;
 import me.rojo8399.placeholderapi.expansions.ServerExpansion;
 import me.rojo8399.placeholderapi.expansions.SoundExpansion;
 import ninja.leaping.configurate.ConfigurationNode;
@@ -70,6 +71,7 @@ public class PlaceholderAPIPlugin {
 		s.registerPlaceholder(new PlayerExpansion());
 		s.registerPlaceholder(new ServerExpansion());
 		s.registerPlaceholder(new SoundExpansion());
+		s.registerPlaceholder(new RankExpansion());
 		if (!Files.exists(path)) {
 			try {
 				conf.copyToFile(path);

--- a/src/main/java/me/rojo8399/placeholderapi/PlaceholderService.java
+++ b/src/main/java/me/rojo8399/placeholderapi/PlaceholderService.java
@@ -1,5 +1,6 @@
 package me.rojo8399.placeholderapi;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 import org.spongepowered.api.entity.living.player.Player;
@@ -10,25 +11,33 @@ public interface PlaceholderService {
 
 	/**
 	 * Replace all placeholders in a string.
-	 * @param player The player to parse with respect to.
-	 * @param text The text to parse.
+	 * 
+	 * @param player
+	 *            The player to parse with respect to.
+	 * @param text
+	 *            The text to parse.
 	 * @return The parsed text.
 	 */
 	public String replacePlaceholders(Player player, String text);
 
 	/**
 	 * Register a placeholder.
-	 * @param expansion The placeholder to register.
+	 * 
+	 * @param expansion
+	 *            The placeholder to register.
 	 * @return Whether the placeholder was successfully registered.
 	 */
 	public boolean registerPlaceholder(Expansion expansion);
 
 	/**
 	 * Register a placholder.
-	 * @param plugin The owner of the placeholder.
-	 * @param function The function that parses placeholders.
+	 * 
+	 * @param plugin
+	 *            The owner of the placeholder.
+	 * @param function
+	 *            The function that parses placeholders.
 	 * @return Whether the placeholder was successfully registered.
 	 */
-	public boolean registerPlaceholder(Object plugin, BiFunction<Player, String, String> function);
+	public boolean registerPlaceholder(Object plugin, BiFunction<Player, Optional<String>, String> function);
 
 }

--- a/src/main/java/me/rojo8399/placeholderapi/PlaceholderServiceImpl.java
+++ b/src/main/java/me/rojo8399/placeholderapi/PlaceholderServiceImpl.java
@@ -29,16 +29,21 @@ public class PlaceholderServiceImpl implements PlaceholderService {
 			String format = placeholderMatcher.group(1);
 			format = format.substring(1, format.length() - 1);
 			int index = format.indexOf("_");
-			if (index <= 0 || index >= format.length()) {
+			if (index == 0 || index == format.length()) {
 				continue;
 			}
-			String id = format.substring(0, index);
+			boolean noToken = false;
+			if (index == -1) {
+				noToken = true;
+				index = format.length();
+			}
+			String id = format.substring(0, index).toLowerCase();
 			if (!expansions.containsKey(id)) {
 				continue;
 			}
-			String token = format.substring(index + 1);
+			String token = noToken ? null : format.substring(index + 1);
 			Expansion exp = expansions.get(id);
-			String value = exp.onPlaceholderRequest(player, token);
+			String value = exp.onPlaceholderRequest(player, Optional.ofNullable(token.toLowerCase()));
 			PlaceholderAPIPlugin.getInstance().getLogger()
 					.debug("Format: " + format + ", ID: " + id + ", Value : " + value);
 			if (value == null) {
@@ -54,15 +59,16 @@ public class PlaceholderServiceImpl implements PlaceholderService {
 		if (!expansion.canRegister()) {
 			return false;
 		}
-		if (expansions.containsKey(expansion.getIdentifier())) {
+		if (expansions.containsKey(expansion.getIdentifier().toLowerCase())) {
 			return false;
 		}
-		expansions.put(expansion.getIdentifier(), expansion);
+		expansions.put(expansion.getIdentifier().toLowerCase(), expansion);
 		return true;
 	}
 
 	@Override
-	public boolean registerPlaceholder(final Object plugin, final BiFunction<Player, String, String> function) {
+	public boolean registerPlaceholder(final Object plugin,
+			final BiFunction<Player, Optional<String>, String> function) {
 		if (plugin == null) {
 			return false;
 		}
@@ -80,7 +86,7 @@ public class PlaceholderServiceImpl implements PlaceholderService {
 
 			@Override
 			public String getIdentifier() {
-				return c.getId();
+				return c.getId().toLowerCase();
 			}
 
 			@Override
@@ -94,7 +100,7 @@ public class PlaceholderServiceImpl implements PlaceholderService {
 			}
 
 			@Override
-			public String onPlaceholderRequest(Player player, String token) {
+			public String onPlaceholderRequest(Player player, Optional<String> token) {
 				return function.apply(player, token);
 			}
 

--- a/src/main/java/me/rojo8399/placeholderapi/expansions/Expansion.java
+++ b/src/main/java/me/rojo8399/placeholderapi/expansions/Expansion.java
@@ -1,5 +1,7 @@
 package me.rojo8399.placeholderapi.expansions;
 
+import java.util.Optional;
+
 import org.spongepowered.api.entity.living.player.Player;
 
 public interface Expansion {
@@ -39,6 +41,6 @@ public interface Expansion {
 	 * 
 	 * @return the result of the parse
 	 */
-	public String onPlaceholderRequest(Player player, String token);
+	public String onPlaceholderRequest(Player player, Optional<String> token);
 
 }

--- a/src/main/java/me/rojo8399/placeholderapi/expansions/PlayerExpansion.java
+++ b/src/main/java/me/rojo8399/placeholderapi/expansions/PlayerExpansion.java
@@ -1,6 +1,9 @@
 package me.rojo8399.placeholderapi.expansions;
 
+import java.util.Optional;
+
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.serializer.TextSerializers;
 
 import me.rojo8399.placeholderapi.PlaceholderAPIPlugin;
 import me.rojo8399.placeholderapi.configs.Config;
@@ -28,14 +31,20 @@ public class PlayerExpansion implements Expansion {
 	}
 
 	@Override
-	public String onPlaceholderRequest(Player p, String identifier) {
-
+	public String onPlaceholderRequest(Player p, Optional<String> identifier) {
 		Config config = PlaceholderAPIPlugin.getInstance().getConfig();
-
 		if (config.expansions.player) {
-			switch (identifier) {
+			if (!identifier.isPresent()) {
+				return p.getName();
+			}
+			switch (identifier.get()) {
+			case "prefix":
+			case "suffix":
+				return p.getOption(identifier.get()).orElse("");
 			case "name":
 				return p.getName();
+			case "displayname":
+				return TextSerializers.FORMATTING_CODE.serialize(p.getDisplayNameData().displayName().get());
 			default:
 				return null;
 			}

--- a/src/main/java/me/rojo8399/placeholderapi/expansions/RankExpansion.java
+++ b/src/main/java/me/rojo8399/placeholderapi/expansions/RankExpansion.java
@@ -2,7 +2,6 @@ package me.rojo8399.placeholderapi.expansions;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.service.permission.Subject;
@@ -62,7 +61,7 @@ public class RankExpansion implements Expansion {
 				return false;
 			}
 			return true;
-		}).collect(Collectors.toList()).get(0);
+		}).findFirst().orElse(subject);
 	}
 
 	/*

--- a/src/main/java/me/rojo8399/placeholderapi/expansions/RankExpansion.java
+++ b/src/main/java/me/rojo8399/placeholderapi/expansions/RankExpansion.java
@@ -1,0 +1,104 @@
+package me.rojo8399.placeholderapi.expansions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.service.permission.Subject;
+
+public class RankExpansion implements Expansion {
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see me.rojo8399.placeholderapi.expansions.Expansion#canRegister()
+	 */
+	@Override
+	public boolean canRegister() {
+		return true;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see me.rojo8399.placeholderapi.expansions.Expansion#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "rank";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see me.rojo8399.placeholderapi.expansions.Expansion#getAuthor()
+	 */
+	@Override
+	public String getAuthor() {
+		return "Wundero";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see me.rojo8399.placeholderapi.expansions.Expansion#getVersion()
+	 */
+	@Override
+	public String getVersion() {
+		return "1.0";
+	}
+
+	private static Subject getParentGroup(Subject subject) {
+		List<Subject> parents = subject.getParents();
+		return parents.stream().filter(parent -> {
+			for (Subject s : parents) {
+				if (s.equals(parent) || s.getIdentifier().equals(parent.getIdentifier())) {
+					continue;
+				}
+				if (parent.isChildOf(s)) {
+					continue;
+				}
+				return false;
+			}
+			return true;
+		}).collect(Collectors.toList()).get(0);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * me.rojo8399.placeholderapi.expansions.Expansion#onPlaceholderRequest(org.
+	 * spongepowered.api.entity.living.player.Player, java.lang.String)
+	 */
+	@Override
+	public String onPlaceholderRequest(Player player, Optional<String> token) {
+		if (!token.isPresent()) {
+			return getParentGroup(player).getIdentifier();
+		}
+		Subject rank = getParentGroup(player);
+		String t = token.get();
+		switch (t) {
+		case "prefix":
+		case "suffix":
+			return rank.getOption(t).orElse("");
+		case "name":
+			return rank.getIdentifier();
+		}
+		if (t.contains("_") && t.indexOf("_") < t.length()) {
+			if (t.startsWith("option")) {
+				String opt = t.substring(t.indexOf("_") + 1);
+				return rank.getOption(opt).orElse("");
+			}
+			// this also covers "permission_..."
+			// return whether the rank has a permission
+			if (t.startsWith("perm")) {
+				String perm = t.substring(t.indexOf("_") + 1);
+				return rank.getPermissionValue(rank.getActiveContexts(), perm).toString();
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/me/rojo8399/placeholderapi/expansions/ServerExpansion.java
+++ b/src/main/java/me/rojo8399/placeholderapi/expansions/ServerExpansion.java
@@ -1,5 +1,7 @@
 package me.rojo8399.placeholderapi.expansions;
 
+import java.util.Optional;
+
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 
@@ -32,12 +34,15 @@ public class ServerExpansion implements Expansion {
 	}
 
 	@Override
-	public String onPlaceholderRequest(Player player, String identifier) {
+	public String onPlaceholderRequest(Player player, Optional<String> identifier) {
 
 		Config config = PlaceholderAPIPlugin.getInstance().getConfig();
 
 		if (config.expansions.server) {
-			switch (identifier) {
+			if (!identifier.isPresent()) {
+				return null;
+			}
+			switch (identifier.get()) {
 			case "online":
 				return String.valueOf(Sponge.getServer().getOnlinePlayers().size());
 			case "ram_used":
@@ -48,6 +53,8 @@ public class ServerExpansion implements Expansion {
 				return String.valueOf(runtime.totalMemory() / MB);
 			case "ram_max":
 				return String.valueOf(runtime.maxMemory() / MB);
+			case "cores":
+				return String.valueOf(runtime.availableProcessors());
 			default:
 				return null;
 			}

--- a/src/main/java/me/rojo8399/placeholderapi/expansions/SoundExpansion.java
+++ b/src/main/java/me/rojo8399/placeholderapi/expansions/SoundExpansion.java
@@ -34,12 +34,16 @@ public class SoundExpansion implements Expansion {
 	}
 
 	@Override
-	public String onPlaceholderRequest(Player p, String identifier) {
+	public String onPlaceholderRequest(Player p, Optional<String> identifier) {
+
+		if (!identifier.isPresent()) {
+			return null;
+		}
 
 		Config config = PlaceholderAPIPlugin.getInstance().getConfig();
 		Game game = PlaceholderAPIPlugin.getInstance().getGame();
 
-		String[] i = identifier.split("-");
+		String[] i = identifier.get().split("-");
 
 		Optional<SoundType> sound = game.getRegistry().getType(SoundType.class, i[0]);
 		Vector3d position = p.getLocation().getPosition();


### PR DESCRIPTION
Placeholder additions:
player_displayname
player_prefix
player_suffix
player - same as player_name
server_cores
rank
rank_name
rank_prefix
rank_suffix
rank_perm_[permission] - returns TRUE, FALSE, or UNDEFINED
rank_option_[option] - get options from ranks, such as prefix

API changes:
Expansion now requires Optional<String> rather than String; this allows the token to not exist (ex: %player%) and forces implementations to properly handle when it does not exist. Service and ServiceImpl have been updated accordingly.
Placeholder handling forced into lower case.
Minor formatting changes because of Eclipse.