### PR TITLE
Added new placeholder 'user'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'me.rojo8399.placeholderapi'
-version = '4.5'
+version = '4.5.1'
 description = 'An API for all of your placeholders.'
 
 compileJava.options.encoding = 'UTF-8'

--- a/src/main/java/me/rojo8399/placeholderapi/impl/PlaceholderAPIPlugin.java
+++ b/src/main/java/me/rojo8399/placeholderapi/impl/PlaceholderAPIPlugin.java
@@ -88,7 +88,7 @@ public class PlaceholderAPIPlugin {
 	private static PlaceholderAPIPlugin instance;
 	public static final String PLUGIN_ID = "placeholderapi";
 	public static final String PLUGIN_NAME = "PlaceholderAPI";
-	public static final String PLUGIN_VERSION = "4.5";
+	public static final String PLUGIN_VERSION = "4.5.1";
 
 	public static PlaceholderAPIPlugin getInstance() {
 		return instance;

--- a/src/main/java/me/rojo8399/placeholderapi/impl/PlaceholderServiceImpl.java
+++ b/src/main/java/me/rojo8399/placeholderapi/impl/PlaceholderServiceImpl.java
@@ -283,7 +283,7 @@ public class PlaceholderServiceImpl implements PlaceholderService {
 			if (value == null && PlaceholderAPIPlugin.getInstance().getConfig().relationaltoregular && rel) {
 				empty = true;
 				try {
-					value = store.parse(id, false, o, s, Optional.ofNullable(token));
+					value = store.parse(id, false, s, o, Optional.ofNullable(token));
 				} catch (Exception e) {
 					if (e instanceof NoValueException) {
 						value = null;

--- a/src/main/java/me/rojo8399/placeholderapi/impl/placeholder/Defaults.java
+++ b/src/main/java/me/rojo8399/placeholderapi/impl/placeholder/Defaults.java
@@ -619,10 +619,28 @@ public class Defaults {
 		}
 	}
 
+	@Placeholder(id = "user")
+	public Object user(@Source User user, @Token(fix = true) @Nullable String token) throws NoValueException {
+		if (token == null) {
+			return user.getName();
+		}
+
+		switch (token) {
+			case "name":
+				return user.getName();
+			case "displayname":
+				return user.getOrElse(Keys.DISPLAY_NAME, Text.of(user.getName()));
+			case "uuid":
+				return user.getUniqueId();
+		}
+
+		throw new NoValueException();
+	}
+
 	@Placeholder(id = "player")
 	public Object normalPlayer(@Source Player p, @Token(fix = true) @Nullable String token) throws NoValueException {
 		if (token == null) {
-			return p.getName();
+			return user(p, null);
 		}
 		if (token.startsWith("option_")) {
 			String op = token.substring("option_".length());
@@ -636,12 +654,6 @@ public class Defaults {
 		case "prefix":
 		case "suffix":
 			return p.getOption(token).orElse("");
-		case "name":
-			return p.getName();
-		case "displayname":
-			return p.getOrElse(Keys.DISPLAY_NAME, Text.of(p.getName()));
-		case "uuid":
-			return p.getUniqueId();
 		case "can_fly":
 			return p.getOrElse(Keys.CAN_FLY, false);
 		case "world":
@@ -730,9 +742,9 @@ public class Defaults {
 				out += f.format(s) + " s";
 			}
 			return out.trim();
-		default:
-			throw new NoValueException();
 		}
+
+		return user(p, token);
 	}
 
 	@Listener


### PR DESCRIPTION
This PR just extracts the name and UUID tokens from the `player` placeholder to a new `user` placeholder. This allows these placeholders to be resolved when the player is offline. There might be _some_ more placeholders in `player` which might be moved over to `user` too.
You might also consider adding `User` to the `validateSource(...)` method. `User` works here because it is a `Subject`.